### PR TITLE
flexible disk space allocation for RNA-seq

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "Benchmark-4dn"
-version = "0.5.25"
+version = "0.5.26"
 description = """Benchmark functions that returns total space, mem, cpu given \
     input size and parameters for the CWL workflows"""
 authors = ["Soo Lee <duplexa@gmail.com>"]

--- a/tests/test.py
+++ b/tests/test.py
@@ -21,23 +21,27 @@ class TestBenchmark(unittest.TestCase):
     def test_encode_rnaseq_unstranded(self):
         print("rnaseq_unstranded")
         input_json = {'input_size_in_bytes': {'rna.fastqs_R1': GB2B(10),
-                                              'rna.align_index': GB2B(3)}}
+                                              'rna.align_index': GB2B(10)}}
         res = B.benchmark('encode-rnaseq-unstranded', input_json)
         print(res)
         assert 'aws' in res
         assert 'recommended_instance_type' in res['aws']
         assert res['aws']['recommended_instance_type'] == 'm5a.4xlarge'
+        assert 'total_size_in_GB' in res
+        assert int(res['total_size_in_GB']) == 145
 
 
     def test_encode_rnaseq_stranded(self):
         print("rnaseq_stranded")
         input_json = {'input_size_in_bytes': {'rna.fastqs_R1': GB2B(10),
-                                              'rna.align_index': GB2B(3)}}
+                                              'rna.align_index': GB2B(10)}}
         res = B.benchmark('encode-rnaseq-stranded', input_json)
         print(res)
         assert 'aws' in res
         assert 'recommended_instance_type' in res['aws']
         assert res['aws']['recommended_instance_type'] == 'm5a.4xlarge'
+        assert 'total_size_in_GB' in res
+        assert int(res['total_size_in_GB']) == 161
 
 
     def test_repliseq(self):


### PR DESCRIPTION
Differentiate disk allocation for RNA-seq pipeline workflows (stranded and unstranded) based on reference file size.
- Distinguishes between organism (using reference file as a proxy) in order to allocate disk more precisely
- Formulae based on analysis of past 4DN RNA-seq runs